### PR TITLE
Fixed typo

### DIFF
--- a/page/page-mainwp-settings.php
+++ b/page/page-mainwp-settings.php
@@ -357,7 +357,7 @@ class MainWP_Settings {
 					<table class="form-table">
 						<tbody>
 						<tr>
-							<th scope="row"><?php _e( 'Hide MainWP Footer', 'mainwp' ); ?>&nbsp;<?php MainWP_Utility::renderToolTip( __( 'If set to YES, fixed footer will be appended to the bottom of the page', 'mainwp' ) ); ?></th>
+							<th scope="row"><?php _e( 'Hide MainWP Footer', 'mainwp' ); ?>&nbsp;<?php MainWP_Utility::renderToolTip( __( 'If set to YES, fixed footer will be removed from the bottom of the page', 'mainwp' ) ); ?></th>
 							<td>
 								<div class="mainwp-checkbox">
 									<input type="checkbox" name="mainwp_hide_footer"


### PR DESCRIPTION
Hide MainWP Footer - tooltip should be "If set to YES, fixed footer will be <strike>appended to</strike> removed from the bottom of the page"
